### PR TITLE
fix preference link on XCL without ALTSYS

### DIFF
--- a/xoops_trust_path/modules/protector/admin/mymenu.php
+++ b/xoops_trust_path/modules/protector/admin/mymenu.php
@@ -41,8 +41,13 @@ if( count( $config_handler->getConfigs( new Criteria( 'conf_modid' , $xoopsModul
 		$title = defined( '_MD_A_MYMENU_MYPREFERENCES' ) ? _MD_A_MYMENU_MYPREFERENCES : _PREFERENCES ;
 		array_push( $adminmenu , array( 'title' => $title , 'link' => 'admin/index.php?mode=admin&lib=altsys&page=mypreferences' ) ) ;
 	} else {
-		// system->preferences
-		array_push( $adminmenu , array( 'title' => _PREFERENCES , 'link' => XOOPS_URL.'/modules/system/admin.php?fct=preferences&op=showmod&mod='.$xoopsModule->mid() ) ) ;
+		if ( $module_handler->getByDirName('legacy') !== FALSE ) {
+			// legacy->preferences
+			array_push( $adminmenu , array( 'title' => _PREFERENCES , 'link' => XOOPS_URL.'/modules/legacy/admin/index.php?action=PreferenceEdit&confmod_id='.$xoopsModule->mid() ) ) ;
+		} else {
+			// system->preferences
+			array_push( $adminmenu , array( 'title' => _PREFERENCES , 'link' => XOOPS_URL.'/modules/system/admin.php?fct=preferences&op=showmod&mod='.$xoopsModule->mid() ) ) ;
+		}
 	}
 }
 


### PR DESCRIPTION
Fix Problem: "Preference" button link to the "System" module on XCL without ALTSYS.

[ja]
ALTSYSがインストールされていないXCLにProtectorをインストールすると、管理画面上(!= 管理メニュー)の「一般設定」のリンク先がsystemモジュールのURLになってしまう問題を修正しました。
[/ja]
